### PR TITLE
Removed all char usage, replaced with byte

### DIFF
--- a/src/VEXnetDriver.java
+++ b/src/VEXnetDriver.java
@@ -28,7 +28,7 @@ public class VEXnetDriver {
     SerialPort serial;
     String serial_port = null;
     boolean showSuccess = false;
-    char[] buffer = new char[10];
+    byte[] buffer = new byte[10];
     int bufferSize = 0;
     int bufferPosition = 0;
 
@@ -77,24 +77,26 @@ public class VEXnetDriver {
             return;
         }
 
-        writeChar((char) 0xAA); // Sync 1
-        writeChar((char) 0x55); // Sync 2
-        writeChar(packet.type);
+        writeBytes(
+                (byte)0xAA, // Sync 1
+                (byte)0x55, // Sync 2
+                packet.type
+        );
 
         if (packet.size != 0) {
-            char Checksum = 0;
+            byte Checksum = 0;
 
-            writeChar(packet.includeChecksum ? (char) (packet.size + 1) : // +1 for Checksum
+            writeBytes(packet.includeChecksum ? (byte) (packet.size + 1) : // +1 for Checksum
                     packet.size);  // +0 for no Checksum
 
             for (int i = 0; i < packet.size; i++) {
-                char Byte = packet.data[i];
-                writeChar(Byte);
+                byte Byte = packet.data[i];
+                writeBytes(Byte);
                 Checksum -= Byte;
             }
 
             if (packet.includeChecksum)
-                writeChar(Checksum);
+                writeBytes(Checksum);
         }
     }
 
@@ -112,26 +114,27 @@ public class VEXnetDriver {
 
         char Checksum = 0;
 
-        if (readChar() != 0xaa) // Sync 1
+
+        if (readByte() != (byte)0xaa) // Sync 1
             return null; // Expect Sync 1
 
-        if (readChar() != 0x55) // Sync 2
+        if (readByte() != 0x55) // Sync 2
             return null; // Expect Sync 2
 
-        char chr = readChar(); // Packet type
+        byte chr = readByte(); // Packet type
         VEXnetPacket.PacketType type = VEXnetPacket.PacketType.get(chr);
         VEXnetPacket packet =
                 type != null ? new VEXnetPacket(type) :
-                        new VEXnetPacket(chr, (char) 0);
+                        new VEXnetPacket(chr, (byte) 0);
 
         // Packet size
-        if (peekChar() == 0 && packet.size == 0) { // If no more data available and data size is zero
+        if (peekByte() == 0 && packet.size == 0) {
+            // If no more data available and the packet is still empty just return
             return packet;
         } else {
             if (packet.size == 0) { // If packet size is zero
-                chr = readChar();
-                packet.size = (char) (chr - 1);
-                packet.data = new char[packet.size];
+                chr = readByte();
+                packet.data = new byte[packet.size = --chr];
             }
             // If packet size does not match expected size
             if ((chr != packet.size + 1 && packet.includeChecksum) || chr != packet.size) {
@@ -141,9 +144,8 @@ public class VEXnetDriver {
         }
 
         for (int i = 0; i < packet.size; i++) {
-            chr = readChar(); // Payload byte
-            packet.data[i] = chr;
-            Checksum += chr;
+            // Payload byte
+            Checksum += packet.data[i] = readByte();
         }
 
         if (Checksum == 0 || !packet.includeChecksum) // If checksum is correct
@@ -169,23 +171,18 @@ public class VEXnetDriver {
         return status;
     }
 
-    boolean writeChar(char Byte) {
-        int code = serial.writeBytes(new byte[]{(byte) Byte}, 1);
-
-        if (code != -1) {
-            if (showSuccess)
-                System.out.println("Bytes written successfully");
-            return true;
+    boolean writeBytes(byte... bytes) {
+        int code = serial.writeBytes(bytes, bytes.length);
+        if(code != -1) {
+            if(showSuccess) System.out.println("Bytes written successfully");
         }
         System.out.println("Error: error while writing data");
         return false;
     }
 
-    char readChar() {
+    byte readByte() {
         if (bufferPosition != bufferSize) {
-            char Byte = buffer[bufferPosition];
-            bufferPosition++;
-            return Byte;
+            return buffer[bufferPosition++];
         }
         byte[] buffer = new byte[this.buffer.length];
         int code = serial.readBytes(buffer, buffer.length);
@@ -193,22 +190,20 @@ public class VEXnetDriver {
         if (code != -1) {
             if (showSuccess)
                 System.out.println("Bytes read successfully");
-            bufferPosition = 0;
-            bufferSize = code;
-            for (int i = 0; i < bufferSize; i++) {
-                this.buffer[i] = (char) buffer[i];
-            }
-            return readChar();
+            System.arraycopy(buffer, 0, this.buffer,
+                    bufferPosition = 0, bufferSize = code
+            );
+            return readByte();
         }
         System.out.println("Error: error while reading the byte");
         return 0;
     }
 
-    char peekChar() {
+    byte peekByte() {
         if (bufferPosition != bufferSize) {
             return buffer[bufferPosition];
         }
-        char Byte = readChar();
+        byte Byte = readByte();
         bufferPosition--;
         return Byte;
     }

--- a/src/VEXnetPacket.java
+++ b/src/VEXnetPacket.java
@@ -18,22 +18,22 @@ public class VEXnetPacket {
         JOY_VERSION_REQUEST(0x3A, 0),
         JOY_VERSION_REQUEST_RESPONSE(0x3B, 2, false);
 
-        final char type, size;
+        final byte type, size;
         final boolean checksum;
         PacketType(int type, int size, boolean checksum) {
-            this.type = (char)type;
-            this.size = (char)size;
+            this.type = (byte)type;
+            this.size = (byte)size;
             this.checksum = checksum;
         }
 
         PacketType(int type, int size) { this(type, size, true); }
 
         // get packet type based on its char attribute
-        public static PacketType get(char type) {
-            return get(type,(char) 0);
+        public static PacketType get(byte type) {
+            return get(type, (byte)0);
         }
 
-        static PacketType get(char type, char size) {
+        static PacketType get(byte type, byte size) {
             for(PacketType t : values()) {
                 if(t.type == type && t.size >= size) return t;
             }
@@ -46,34 +46,29 @@ public class VEXnetPacket {
         }
     }
 
-    char type = 0, size = 0;
-    char[] data = null;
+    byte type, size;
+    byte[] data;
     boolean includeChecksum = true;
 
     public VEXnetPacket() { }
 
-    public VEXnetPacket(PacketType type)
-    { this(type, null); }
-
-    public VEXnetPacket(PacketType type, char data[]) {
-        this(type.type, type.size, data, type.checksum);
+    public VEXnetPacket(PacketType type, byte... data) {
+        this(type.type, type.size, type.checksum, data);
     }
 
-    VEXnetPacket(char type, char size)
-    {this(type, size, null, true);}
+    VEXnetPacket(byte type) { this(type, (byte) 0); }
+    VEXnetPacket(byte type, byte size, byte... data)
+    {this(type, size, true, data);}
 
-    VEXnetPacket(char type, char size, char data[])
-    {this(type, size, data, true);}
-
-    VEXnetPacket(char type, char size, char data[], boolean includeChecksum) {
+    VEXnetPacket(byte type, byte size, boolean includeChecksum, byte... data) {
         this.type = type;
         this.size = size;
-        this.data = data != null ? data : new char[size];
+        this.data = data.length > 0 ? data : new byte[size];
         this.includeChecksum = includeChecksum;
     }
 
     VEXnetPacket(VEXnetPacket packet) {
-        this(packet.type, packet.size, null, packet.includeChecksum);
+        this(packet.type, packet.size, packet.includeChecksum);
         System.arraycopy(this.data, 0, packet.data, 0, this.size);
     }
 
@@ -84,32 +79,32 @@ public class VEXnetPacket {
         PacketType pt = PacketType.get(this);
         str.append(pt != null ? pt : "UNKNOWN_PACKET_TYPE")
            .append('\n')
-           .append(String.format("Type: 0x%02X", (int)this.type))
+           .append(String.format("Type: 0x%02X", this.type))
            .append("\n")
            .append("Size: ")
-           .append(Integer.toString(this.size))
+           .append(size)
            .append("\n");
         str.append("Data: ");
-        if (data != null) for(char c : data) str.append(String.format("%02X ", (int)c));
+        if (data.length > 0) for(byte b : data) str.append(String.format("%02X ", b));
         else str.append("None");
         return str.toString();
     }
 
-    public static VEXnetPacket compileControllerPacket(char joystick_1,
-                                                       char joystick_2,
-                                                       char joystick_3,
-                                                       char joystick_4,
+    public static VEXnetPacket compileControllerPacket(byte joystick_1,
+                                                       byte joystick_2,
+                                                       byte joystick_3,
+                                                       byte joystick_4,
                                                        boolean _5D, boolean _5U,
                                                        boolean _6D, boolean _6U,
                                                        boolean _7D, boolean _7L, boolean _7U, boolean _7R,
                                                        boolean _8D, boolean _8L, boolean _8U, boolean _8R,
-                                                       char accel_Y,
-                                                       char accel_X,
-                                                       char accel_Z) {
-        char[] data = {
+                                                       byte accel_Y,
+                                                       byte accel_X,
+                                                       byte accel_Z) {
+        byte[] data = {
             joystick_1, joystick_2, joystick_3, joystick_4,
-            (char) ((_5D ? (char) 0x01 : 0) | (_5U ? (char) 0x02 : 0) | (_6D ? (char) 0x04 : 0) | (_6U ? (char) 0x08 : 0)),
-            (char) ((_7D ? (char) 0x01 : 0) | (_7L ? (char) 0x02 : 0) | (_7U ? (char) 0x04 : 0) | (_7R ? (char) 0x08 : 0) |
+            (byte) ((_5D ? (char) 0x01 : 0) | (_5U ? (char) 0x02 : 0) | (_6D ? (char) 0x04 : 0) | (_6U ? (char) 0x08 : 0)),
+            (byte) ((_7D ? (char) 0x01 : 0) | (_7L ? (char) 0x02 : 0) | (_7U ? (char) 0x04 : 0) | (_7R ? (char) 0x08 : 0) |
                     (_8D ? (char) 0x10 : 0) | (_8L ? (char) 0x20 : 0) | (_8U ? (char) 0x40 : 0) | (_8R ? (char) 0x80 : 0)),
             accel_Y, accel_X, accel_Z
         };

--- a/src/VEXnetPacket.java
+++ b/src/VEXnetPacket.java
@@ -1,7 +1,6 @@
 /**
- * @file VEXnetPacketjava
  * @author Eric Heinke (sudo-Eric), Zrp200
- * @version 0.5a
+ * @version 1.0
  * @date October 5, 2022
  * @brief Code for communicating using the VEXnet
  */
@@ -75,7 +74,6 @@ public class VEXnetPacket {
     @Override
     public String toString() {
         StringBuilder str = new StringBuilder("Packet: ");
-        str.append(PacketType.get(this));
         PacketType pt = PacketType.get(this);
         str.append(pt != null ? pt : "UNKNOWN_PACKET_TYPE")
            .append('\n')

--- a/src/main.java
+++ b/src/main.java
@@ -1,7 +1,7 @@
 /**
  * @file main.java
  * @author Eric Heinke (sudo-Eric), Zrp200
- * @version 0.5a
+ * @version 1.0
  * @date October 5, 2022
  * @brief Code for communicating using the VEXnet
  */
@@ -10,7 +10,7 @@
 import com.fazecast.jSerialComm.SerialPort;
 
 public class main {
-    public static void main(String[] args) {
+    public static void main(String[] args) throws InterruptedException {
 
         SerialPort[] ports = SerialPort.getCommPorts();
 
@@ -41,7 +41,12 @@ public class main {
 
         VEXnetDriver driver = new VEXnetDriver(comPort, VEXnetDriver.DeviceType.VEXnet_Joystick_Partner_Port);
 
-        for(int i = 0; i < 100; i++)
-            driver.SendVexProtocolPacket(packet);
+        for(int i = 0; i < 100; i++) {
+//            driver.SendVexProtocolPacket(packet);
+            VEXnetPacket packet2 = driver.ReceiveVexProtocolPacket();
+            if (packet2 != null)
+                System.out.println(packet2);
+            Thread.sleep(100);
+        }
     }
 }

--- a/src/main.java
+++ b/src/main.java
@@ -26,12 +26,12 @@ public class main {
         }
 
         VEXnetPacket packet = VEXnetPacket.compileControllerPacket(
-                (char)127, (char)127, (char)127, (char)127,
+                (byte)127, (byte)127, (byte)127, (byte)127,
                 false, false,
                 true, false,
                 false, false, false, false,
                 false, false, false, false,
-                (char)127, (char)127, (char)127);
+                (byte)127, (byte)127, (byte)127);
 //        System.out.println(packet);
 
         SerialPort comPort = ports[0];


### PR DESCRIPTION
A lot of our `char` usage appears to be unnecessary, and using `char` means that we have to convert *from* `byte` when working with the Serial Port API, giving us a really good reason to consider using `byte` as well.

As such, I have removed virtually all of them (except for one place in compileControllerPacket where it literally didn't matter).

Packet:

* changed constructors to use varargs, allowing removal of several overloads.
* checksum argument moved because of this.

VEXnetDriver:

* readChar -> readByte
* peekChar -> peekByte
* writeChar -> writeBytes
   - converted to varargs to prevent repetitive calls.